### PR TITLE
Update numpy version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.12.0
+numpy<=1.26.4
 scipy>=0.18.1
 scikit-learn>=0.19.1
 pandas>=0.25


### PR DESCRIPTION
This is necessary to maintain compatibility with PHATE.

PHATE was updated 7 months ago, but scprep was not. So the usability between both is messy. It works only if you download scprep first and then phate.